### PR TITLE
added "default='/dev/null'" for `--l10handler`

### DIFF
--- a/sdm-cportal
+++ b/sdm-cportal
@@ -417,7 +417,7 @@ if __name__ == "__main__":
     parser.add_argument('--logging', help="Script to do boot-time message logging")
     parser.add_argument('--debug', help="Print logged messages on console also", action='store_true')
     parser.add_argument('--facility', help="Facility name to use instead of 'sdm'")
-    parser.add_argument('--l10nhandler', help="Full path to script to handle Localization data")
+    parser.add_argument('--l10nhandler', help="Full path to script to handle Localization data", default='/dev/null')
     args = parser.parse_args()
     pd.apssid = args.apssid if args.apssid != None else "sdm"
     pd.ip = args.apip if args.apip != None else "10.1.1.1"


### PR DESCRIPTION
I added this little bit which allows `sdm-cportal` to run outside of an `sdm` installation and doesn't require the `--l10handler` flag to be set to `/dev/null`
No idea if this breaks things upstream that rely on it defaulting to `/etc/sdm/local-1piboot.conf` as it does in the If statement at line 222:
```
... line 221
   if ostr != "":
        if pd.l10nhandler != "":
            tfcmd('{} "{}" "{}" "{}"'.format(pd.l10nhandler, keymap, locale, timezone))
        else:
            with open("/etc/{}/local-1piboot.conf".format(pd.facname), 'w') as f:
                f.write("{}\n".format(ostr))
```

So if this does break things, then of course nevermind and keep up the good work :+1: