### PR TITLE
Fix --bootset: Wrong parameter order in parser

### DIFF
--- a/sdm-cparse
+++ b/sdm-cparse
@@ -416,7 +416,7 @@ function setbootset() {
 		    echo "$key=$value" >> $mnt/etc/sdm/auto-1piboot.conf
 		fi
 	    else
-		doconfigitem logtoboth $key $value
+		doconfigitem $key $value logtoboth
 	    fi
 	done
     fi


### PR DESCRIPTION
setbootset() calls doconfigitem with parameters in wrong order.

Instead of
`doconfigitem logtoboth $key $value`
it must be
`doconfigitem $key $value logtoboth`

according to documentation of function doconfigitem

```
function doconfigitem() {
    #
    # $1: function keyword
    # $2: value
    # $3: "" or "bootlog" (first boot) or "logtoboth" (phase1)
```
