### PR TITLE
Enable non-interactive use without tty

### DIFF
--- a/sdm
+++ b/sdm
@@ -28,13 +28,21 @@
 #
 
 function errexit() {
-    echo -e "$1" > $(tty)
+    if [ -t 0 ]; then
+        echo -e "$1" > $(tty)
+    else
+        echo -e "$1"
+    fi
     docleanup
     exit 1
 }
 
 function ferrexit() {
-    [ "$1" != "" ] && printf "$1" > $(tty)
+    if [ -t 0 ]; then
+        [ "$1" != "" ] && printf "$1" > $(tty)
+    else
+        [ "$1" != "" ] && printf "$1"
+    fi
     docleanup
     exit 1
 }
@@ -1251,7 +1259,11 @@ fi
 
 [ $icolors -eq 1 ] && stermcolors "$efg" "$ebg" "$ecursor" xt
 trap "ctrlcexit" SIGINT
-systemd-nspawn -q --directory=$SDMPT $nspawnsw $spawncmd < $(tty)
+if [ -t 0 ]; then
+    systemd-nspawn -q --directory=$SDMPT $nspawnsw $spawncmd < $(tty)
+else
+    systemd-nspawn -q --directory=$SDMPT $nspawnsw $spawncmd
+fi
 [ $icolors -eq 1 ] && resetcolors xt
 docleanup
 

--- a/sdm-cmdsubs
+++ b/sdm-cmdsubs
@@ -317,13 +317,21 @@ function sdm_burndevfile() {
 	if [ "$bcp" != "" ]
 	then
 	    logtoboth "> Change passwords per --password-pi, --password-user, and/or --password-root"
-	    systemd-nspawn -q --directory=$SDMPT $sdmdir/sdm-phase1 burn-change-passwords $(basename $bcp) < $(tty)
+		if [ -t 0 ]; then
+	    	systemd-nspawn -q --directory=$SDMPT $sdmdir/sdm-phase1 burn-change-passwords $(basename $bcp) < $(tty)
+		else
+	    	systemd-nspawn -q --directory=$SDMPT $sdmdir/sdm-phase1 burn-change-passwords $(basename $bcp)
+		fi
 	fi
 	if [ "$b1script" != "" ]
 	then
 	    logtoboth "> Run --b1script '$b1script'"
 	    declare -x SDMNSPAWN="Burn1"
-	    systemd-nspawn -q --directory=$SDMPT $sdmdir/sdm-phase1 b1script $b1script < $(tty)
+		if [ -t 0 ]; then
+	    	systemd-nspawn -q --directory=$SDMPT $sdmdir/sdm-phase1 b1script $b1script < $(tty)
+		else
+	    	systemd-nspawn -q --directory=$SDMPT $sdmdir/sdm-phase1 b1script $b1script
+		fi
 	fi
 	declare -x SDMNSPAWN="Burn0"
 	logtoboth "* Burn Completed"

--- a/sdm-gburn
+++ b/sdm-gburn
@@ -3,12 +3,20 @@
 version="2.0"
 
 function errexit() {
-    echo -e "$1" > $(tty)
+    if [ -t 0 ]; then
+        echo -e "$1" > $(tty)
+    else
+        echo -e "$1"
+    fi
     exit 1
 }
 
 function ferrexit() {
-    [ "$1" != "" ] && printf "$1" > $(tty)
+    if [ -t 0 ]; then
+        [ "$1" != "" ] && printf "$1" > $(tty)
+    else
+        [ "$1" != "" ] && printf "$1"
+    fi
     doumount
     cleanup
     exit 1


### PR DESCRIPTION
Running in a non-interactive shell (i.e. on a CI server) is currently not possible, because $(tty) is used for printing and some features.
This patch checks for TTY and calls the corresponding commands without $(tty) when appropriate.

Please check if I missed it somewhere!