### PR TITLE
change getgbstr to use bash instead of python3

### DIFF
--- a/sdm-cparse
+++ b/sdm-cparse
@@ -191,9 +191,9 @@ function getgbstr() {
     # Returns the string "(nn.nnGB, mm.mmGiB)"
 
     local nbytes=$1
-    local gib=$((1024*1024*1024)) gb=$((1000*1000*1000))  # Not super-efficient but meh
-    ngbytes=$(python3 -c "print(\"{:.1f}\".format(round($nbytes/$gb, 2)))")
-    ngibytes=$(python3 -c "print(\"{:.1f}\".format(round($nbytes/$gib, 2)))")
+    local gb=1000000000 gib=1073741824
+    ngbytes=$(printf %.2f "$((100 * $nbytes / $gb))e-2")
+    ngibytes=$(printf %.2f "$((100 * $nbytes / $gib))e-2")
     echo "(${ngbytes}GB, ${ngibytes}GiB)"
     return
 }


### PR DESCRIPTION
Please consider using a more POSIX compliant way to `getgbstr` as python3 may not yet be installed on the system being customized. Also changed gb and gib to hold their actual values as (with my invocation of sdm), the function is called 11 times.

Changes work w/ bash. Additionally, I believe the initial intention was 2 decimals, due to the `# Returns the string "(nn.nnGB, mm.mmGiB)"` and `round($nbytes/$gb, 2)`. If this is not the case, the `100` and `e-2` can be adjusted to desired precision.