### PR TITLE
Reference `disables` plugin in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ curl -L https://raw.githubusercontent.com/gitbls/sdm/master/EZsdmInstaller | bas
 
 ## Customize the image with sdm
 ```sh
-sudo sdm --customize --plugin user:"adduser=bls|password=mypassword" --plugin L10n:host --plugin disable:piwiz --regen-ssh-host-keys --restart 2023-05-03-raspios-bullseye-arm64.img
+sudo sdm --customize --plugin user:"adduser=bls|password=mypassword" --plugin L10n:host --plugin disables:piwiz --regen-ssh-host-keys --restart 2023-05-03-raspios-bullseye-arm64.img
 ```
 
 sdm will make the following changes to your IMG file:


### PR DESCRIPTION
It appears that at some point the plugin was renamed from `disable` to `disables`. This led to an error "? Unrecognized plugin 'disable'" when trying the example.