### PR TITLE
Fix unrecognized key 'userdel' in "user" plugin

### DIFF
--- a/sdm-gburn
+++ b/sdm-gburn
@@ -244,7 +244,7 @@ do
 		    [ "$reboot" != "0" ] && rb="--reboot $reboot" || rb=""
 		    [ "$autologin" == "yes" ] && al="--autologin" || al=""
 		    trap "doctrlc" SIGINT
-		    [ "$keepi" != "yes" ] && pins="--plugin user:userdel=pi"
+		    [ "$keepi" != "yes" ] && pins="--plugin user:deluser=pi"
 		    [ -f $plugfile ] && pins="$pins --plugin @$plugfile"
 		    [ "$pluglist" != "" ] && pins="$pins --plugin @pluglist"
 		    echo "sdm --burn $burndev --hostname $hostname --expand-root  --regen-ssh-host-keys $rb $al $pins $img"


### PR DESCRIPTION
Example error message:
```
> Set MBR partition Disk ID in cmdline.txt
> Set MBR partition Disk ID in fstab
> Disable unneeded RasPiOS firstboot service and /etc/init.d/resize2fs_once
> Disable regenerate_ssh_host_keys service; sdm FirstBoot will run it instead
> Set hostname 'customer1'
> First System Boot Custom Boot Scripts disabled
> First System Boot automatic restart enabled
* Plugins selected:
   * user
       Args: userdel=pi
   * user
       Args: adduser=customer_1|password=secretpasswd
   * disables
       Args: piwiz
> Run Plugins Phase '0'
> Run Plugin 'user' (/mnt/sdm/usr/local/sdm/plugins/user) Phase 0 with arguments: 'userdel=pi'
* Plugin user: Start Phase 0
? Plugin user: Unrecognized key 'userdel' in argument list 'userdel=pi'
? Plugin 'user' exited with failure
```