### PR TITLE
bugfix: handle decimal values of partsize

### DIFF
--- a/sdm-cparse
+++ b/sdm-cparse
@@ -1325,7 +1325,7 @@ function extendimage() {
     done < <(parted -sm $ldimg unit MB print)
     partstart=${partstart%MB}
     imgend=${imgend%MB}
-    partsize=$((imgend-partstart))
+    partsize=$(bc <<< "$imgend - $partstart")
     echo "* Resize partition 2 of '$ldimg' to ${partsize}MB"
     parted $ldimg -s resizepart 2 ${imgend}MB
 }


### PR DESCRIPTION
Bash arithmetic operations only work for integers, which means `--extend` will fail if it hits any decimals in `partstart` or `imgend`.

This PR switches the calculation to use `bc` to avoid the issue.