### PR TITLE
Change cryptsetup encryption to aes cbc

### DIFF
--- a/sdm-cryptconfig
+++ b/sdm-cryptconfig
@@ -312,11 +312,12 @@ EOF
     echo "> Update /etc/initramfs-tools/modules to include crypto modules"
     cat >> /etc/initramfs-tools/modules <<EOF
 algif_skcipher
-xchacha20
-adiantum
-aes_arm
-sha256
-nhpoly1305
+aes_arm64
+aes_ce_blk
+aes_ce_ccm
+aes_ce_cipher
+sha256_arm64
+cbc
 dm-crypt
 EOF
     echo "> Enable KEYMAP=y in /etc/initramfs-tools/initramfs.conf"

--- a/sdmcryptfs
+++ b/sdmcryptfs
@@ -91,7 +91,7 @@ function cryptpart() {
     pmsg "OK to ignore superblock signature warning"
     while [ 0 ]
     do
-	cryptsetup luksFormat --type luks2 --cipher xchacha20,aes-adiantum-plain64 --hash sha256 --iter-time 5000 --key-size 256 --pbkdf argon2i  $rootfs
+	cryptsetup luksFormat --type luks2 --cipher aes-cbc-essiv:sha256 --hash sha256 --iter-time 5000 --key-size 256 --pbkdf argon2i  $rootfs
 	[ $? -eq 0 ] && break
     done
     return 0


### PR DESCRIPTION
The Raspberry Pi 5 includes AES acceleration (AES-256-CBC). This is much faster than xchacha20,aes-adiantum-plain64

```# Tests are approximate using memory only (no storage IO).
#            Algorithm |       Key |      Encryption |      Decryption
xchacha20,aes-adiantum        256b       398.9 MiB/s       418.8 MiB/s
               aes-cbc        256b       886.1 MiB/s      1848.6 MiB/s
```

I have tested these changes on my raspberryi pi 5 and works like a charm. Thanks for sdm.

Sources:
https://www.hackster.io/news/raspberry-pi-5-review-hands-on-with-the-most-powerful-raspberry-pi-yet-57efaf61b10f
https://www.raspberrypi.com/news/introducing-raspberry-pi-5/
https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#raspberry-pi-5