### PR TITLE
Parted uses a minimum alignment of 1Mbyte for some disks

### DIFF
--- a/plugins/parted
+++ b/plugins/parted
@@ -156,6 +156,10 @@ function makepartition() {
     [ $optimal_io_size -le 0 ] && optimal_io_size=1048576  #1024*1024
     physical_block_size=$(cat /sys/block/$pdevnm/queue/physical_block_size)
     alignment_offset=$(cat /sys/block/$pdevnm/alignment_offset)
+    if [ "$align_to_sector" -lt 2048 ]
+    then
+        align_to_sector=2048
+    fi
     align_to_sector=$(((optimal_io_size+alignment_offset)/physical_block_size))
     aligned_start_sector=$((((free_space_start/align_to_sector) + 1)*align_to_sector))
     aligned_end_sector=$(((free_space_start+((psize*1048576)/512))/align_to_sector*align_to_sector-1))
@@ -167,6 +171,7 @@ function makepartition() {
 	partend=$aligned_end_sector
     fi
     pdname="$(getspname $pdev $partnum)"
+    #logtoboth "> Plugin $pfx: plugindebug: $plugindebug"
     [ "$plugindebug" == "" ] && plugindebug=0  #cya
     if [ $plugindebug -eq 1 ]
     then
@@ -248,7 +253,7 @@ phase=$1
 pfx="$(basename $0)"     #For messages
 args="$2"
 loadparams
-vldargs="|burndev|burnfilefile|imgtype|rootexpand|addpartition|"
+vldargs="|plugindebug|burndev|burnfilefile|imgtype|rootexpand|addpartition|"
 rqdargs=""                   # |list|of|required|args|or|nullstring|
 assetdir="$SDMPT/etc/sdm/assets/$pfx"
 


### PR DESCRIPTION
I am using the Raspberry IP official 256GB SSD's, `fdisk -l` labels it as  SAMSUNG MZ9LQ256HBJD-00BVL.

parted is calculating an optimal alignment of 2048 sectors, which triggers the following output and subsequent prompt:

```
> Run Plugin 'parted' (/usr/local/sdm/local-plugins/parted) Phase burn-complete with arguments: 'plugindebug=1|rootexpand=37305|addpartition=0,ext4|burndev=/dev/nvme0n1|burnfilefile=|imgtype=Device'
> Plugin parted: Keys/values found:
   plugindebug: 1
   rootexpand: 37305
   addpartition: 0,ext4
   burndev: /dev/nvme0n1
   burnfilefile:
   imgtype: Device
> Plugin partedExpandPartition: partstart: 541065216
> Plugin partedExpandPartition: partend: 3829000191
> Plugin partedExpandPartition: partsize: 6421748
> Plugin partedExpandPartition: devsize: 500118192
> Plugin partedExpandPartition: partsize: 6421748
> Plugin partedExpandPartition: pbytes: 3287934976
> Plugin partedExpandPartition: nbytes: 42405062656
> Expand Root: Expand root partition 'nvme0n1p2' (ext4) on device '/dev/nvme0n1' from (3.3GB, 3.1GiB) to (42.4GB, 39.5GiB)
* Mount /dev/nvme0n1 to resize the root file system
* Mount device '/dev/nvme0n1' mount: /dev/nvme0n1p2 mounted on /mnt/sdm.
mount: /dev/nvme0n1p1 mounted on /mnt/sdm/boot/firmware.
* Resize the ext4 root file system % (Ignore 'on-line resizing required' message)
resize2fs 1.47.0 (5-Feb-2023)
Filesystem at /dev/nvme0n1p2 is mounted on /mnt/sdm; on-line resizing required old_desc_blocks = 1, new_desc_blocks = 3
The filesystem on /dev/nvme0n1p2 is now 10352796 (4k) blocks long.

umount: /mnt/sdm/boot/firmware unmounted
umount: /mnt/sdm unmounted
> Plugin parted: pdname: /dev/nvme0n1p3
> Plugin parted: partnum: 3
> Plugin parted: partstart: 83879168
> Plugin parted: partend: 500118191
> Plugin parted: psize: 0
> Plugin parted: optimal_io_size: 131072
> Plugin parted: physical_block_size: 512
> Plugin parted: alignment_offset: 0
> Plugin parted: align_to_sector: 256
> Plugin parted: aligned_start_sector: 83879168
> Plugin parted: aligned_end_sector: 83878911
> Plugin parted: free_space_start: 83879157
> Plugin parted: free_space_end: 500118191
> Plugin parted: free_space_amount: 416239035
> Plugin parted: Make primary partition 3 start: 83879168s end: 500118191s
Warning: The resulting partition is not properly aligned for best performance: 83879168s % 2048s != 0s Ignore/Cancel?
```

The above output was generated with "plugindebug" added as an argument to the parted plugin. I could not figure out how to use the `--plugin-debug` flag.