### PR TITLE
Allows specifying the subnet on a static IPv4 address

### DIFF
--- a/Docs/Plugins.md
+++ b/Docs/Plugins.md
@@ -706,7 +706,7 @@ All arguments except `dhcpcdappend`, `dhcpcdwait`, `nowifi`, and `wpa` are valid
 * **noipv6** &mdash; Specifies that IPv6 should be disabled for this connection. Works with both `netman=dhcpcd` and `netman=nm`
 * **nowifi** &mdash; If `netman=dhcpcd` and WiFi settings not configured, this prevents a warning message about no WiFi configured
 * **powersave** &mdash; Specify the WiFi powersave setting. Values: **0**:Use default value; **1**:Leave as is; **2**:Disable powersave; **3**:Enable powersave
-* **ipv4-static-ip** &mdash; Configure the connection with this static IP address
+* **ipv4-static-ip** &mdash; Configure the connection with this static IP address and subnet mask. When no subnet mask is present the `/24` subnet is added as a default subnet
 * **ipv4-static-gateway** &mdash; Configure the connection with this static gateway
 * **ipv4-static-dns** &mdash; Configure the connection with this DNS server IP
 * **ipv4-static-dns-search** &mdash; Set DNS suffix search list for the configuration (Ex: `ipv4-static-dns-search=my.com,dyn.my.com`)

--- a/plugins/network
+++ b/plugins/network
@@ -408,12 +408,15 @@ EOF
 
 		if [ "$ipv4__static__ip" != "" ]
 		then
+		    if [[ $ipv4__static__ip != *"/"* ]]; then
+			    ipv4__static__ip="${ipv4__static__ip}/24"
+		    fi
 		    logtoboth "> Plugin $pfx: Configure connection '$thiscname' for a Static IP"
 		    logtoboth "  Static IP:                $ipv4__static__ip"
 		    logtoboth "  Static Gateway:           $ipv4__static__gateway"
 		    logtoboth "  Static DNS Server:        $ipv4__static__dns"
 		    logtoboth "  Static DNS Domain Search: $ipv4__static__dns__search"
-		    thisattr="$thisattr ipv4.addresses $ipv4__static__ip/24 ipv4.method manual"
+		    thisattr="$thisattr ipv4.addresses $ipv4__static__ip ipv4.method manual"
 		    [ "$ipv4__static__gateway" != "" ] && thisattr="$thisattr ipv4.gateway $ipv4__static__gateway"
 		    [ "$ipv4__static__dns" != "" ] && thisattr="$thisattr ipv4.dns  $ipv4__static__dns"
 		    [ "$ipv4__static__dns__search" != "" ] && thisattr="$thisattr ipv4.dns-search $ipv4__static__dns__search"


### PR DESCRIPTION
The network plugin uses a hardcoded `/24` subnet on a static ipv4 address. This PR allows to override the default by specifying by adding a custom subnet to the IP address. When no subnet is specified it defaults to the `/24` subnet to maintain backward compatibility.
