### PR TITLE
sdm-cparse: add "nbd" to ispdevp()

### DIFF
--- a/sdm-cparse
+++ b/sdm-cparse
@@ -562,7 +562,7 @@ function is64bit() {
 
 function ispdevp() {
     local dev="$1"
-    [[ "$dev" =~ "mmcblk" ]] || [[ "$dev" =~ "nvme" ]] && return 0 || return 1
+    [[ "$dev" =~ "mmcblk" ]] || [[ "$dev" =~ "nvme" ]] || [[ "$dev" =~ "nbd" ]] && return 0 || return 1
 }
 
 function getspname() {


### PR DESCRIPTION
Hello,

I am using `nbd-server` and `nbd-client` to forward an SD card device on my desktop Linux (named `/dev/sda` or `/dev/sdb`) to a remote Debian server, where the forwarded device is named `/dev/nbd0`.

If I run `sdm --burn ...` on the server to burn an image to `/dev/nbd0`, the script thinks that the partitions are named `/dev/nbd00`, `/dev/nbd01`, etc., but they are actually named `/dev/nbd0p1`, `/dev/nbd0p2`, etc. This pull request fixes the issue.