### PR TITLE
Update readme for consistency with docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,7 @@ Here's how to quickly and easily to create and customize an IMG file and burn it
 
 **Throughout this document read "SD Card" as "SSD or SD Card".** sdm treats them equivalently.
 
-# Installing or Removing sdm
-
-## Installing sdm
+## Install sdm
 
 ```sh
 curl -L https://raw.githubusercontent.com/gitbls/sdm/master/install-sdm | bash


### PR DESCRIPTION
At the moment the readme still refers to the old installer which may make lazy users use the package for months without realising they are using the outdated ezinstaller. This change should make it easy for someone only reading the readme to use the non deprecated installer.

Thanks for the amazing repo and hard work! Love it