### PR TITLE
Fix sdm-gburn not finding pluglist, applying --reboot

### DIFF
--- a/sdm-gburn
+++ b/sdm-gburn
@@ -169,7 +169,7 @@ do
 	sudo="yes"
 	piwiz="no"
 	autologin="no"
-	reboot="10"
+	reboot="0"
 	mouse="right"
 	nmconn=""
 	pluglist=""


### PR DESCRIPTION
Hi @gitbls,

love the project, very smooth experience :)

I couldn't get pluglists to work with sdm-gburn. Also it applied --reboot without specifying it, contrary to the documentation.
