### PR TITLE
Fix disk space check to use image filesystem instead of host

### DIFF
--- a/sdm-cparse
+++ b/sdm-cparse
@@ -435,7 +435,7 @@ function logfreespace() {
     free1k=$(getfsdf $dev avail) 
     freeby=$(($free1k*1024))
     logtoboth "> $dimgdevname '$dimg' has $free1k 1K-blocks $(getgbstr $freeby) free $extramsg" nosplit
-    dused=$(getfsdf / pcent)
+    dused=$(getfsdf $dev pcent)
     if [ $dused -ge 98 ]
     then
 	logtoboth "!!! ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** ***** !!!"


### PR DESCRIPTION
## Summary
- Fixed `logfreespace()` in `sdm-cparse` to check disk space on the mounted image (`$dev`) instead of always checking the host's root filesystem (`/`)

## Problem
The function was incorrectly using a hardcoded `/` path when checking percentage used (line 438), while correctly using `$dev` for available space (line 435). This caused false "disk full" errors when the host filesystem was nearly full, even if the image had plenty of space.

## Fix
Changed `dused=$(getfsdf / pcent)` to `dused=$(getfsdf $dev pcent)` to be consistent with the existing `free1k=$(getfsdf $dev avail)` call.