### PR TITLE
revive btrfs-config plugin & add --convert-root-mount-options

### DIFF
--- a/Docs/Command-Details.md
+++ b/Docs/Command-Details.md
@@ -76,6 +76,7 @@ All files that you provide to sdm, whether on the command line or in arguments t
     * This is very handy when you're in the process of developing a new plugin or updating an existing plugin
 * `--chroot` &mdash; By default sdm uses `systemd-nspawn` to enter the container in Phase 1/post-install phases. Some (likely older) host OSes may have issues with that. If `systemd-nspawn` fails with an `execve` error, retry the command and add `--chroot`.
 * `--convert-root fstype[,[+]size]` &mdash; Use with `--burn` to create disks with either `btrfs` or `lvm` rootfs. See <a href="Disks-Partitions.md#rootfs-conversion">Disks and Partitions</a>
+* `--convert-root-mount-options "options"` &mdash; Specify mount options for the converted rootfs. The options are passed to `mount -o` when mounting the rootfs for the burn process. For example, `--convert-root-mount-options "compress=zstd"` to enable compression when burning to a btrfs.
 * `--cscript` *scriptname* &mdash; Specifies the path to your Custom Phase Script, which will be run as described in the Custom Phase Script section below.
 * `--csrc` */path/to/csrcdir* &mdash; A source directory string that can be used in your Custom Phase Script. One use for this is to have a directory tree where all your customizations are kept, and pass in the directory tree to sdm with `--csrc`. 
 * `--custom[1-4]` &mdash; 4 variables (custom1, custom2, custom3, and custom4) that can be used to further customize your Custom Phase Script.

--- a/Docs/Disks-Partitions.md
+++ b/Docs/Disks-Partitions.md
@@ -15,6 +15,7 @@ There are a few switches that change the burn function with respect to disks and
 * `--gpt` &mdash; Convert the burned disk to GPT partition format
 * `--burn-plugin parted` &mdash; Use the `parted` burn plugin to do disk partitioning functions after the burn has completed. See <a href="Plugins.md">Plugins</a>
 * `--convert-root` fmt[,[+]size] &mdash; Convert the rootfs to a different file system, rather than ext4. See the next section
+* `--convert-root-mount-options "options"` &mdash; Specify mount options for the converted rootfs (e.g., `"compress=zstd"` for btrfs)
 * `--expand-root` &mdash; sdm will expand the rootfs to the whole disk after burning
 * `--no-expand-root` &mdash; sdm will not expand rootfs and will disable automatic RasPiOS rootfs expansion
 

--- a/Docs/Disks-Partitions.md
+++ b/Docs/Disks-Partitions.md
@@ -41,6 +41,7 @@ The `--convert-root` switch takes an optional argument `size`, which specifies t
 * `sdm --burn /dev/sdc --convert-root btrfs --expand-root /path/to/2023-12-05-raspios-bookworm-arm64.img` &mdash; Burn the IMG to /dev/sdc with a `btrfs` file system for rootfs
 * `sdm --burn /dev/sdc --convert-root btrfs,8192 --expand-root /path/to/2023-12-05-raspios-bookworm-arm64.img` &mdash; As above, but make rootfs 8192MB (8GB)
 * `sdm --burn /dev/sdc --convert-root btrfs,+8192 --expand-root /path/to/2023-12-05-raspios-bookworm-arm64.img` &mdash; As above, but increase the size of rootfs by 8192MB
+* `sdm --burn /dev/sdc --convert-root btrfs --convert-root-mount-options compress=zstd --burn-plugin btrfs-config /path/to/2023-12-05-raspios-bookworm-arm64.img` &mdash; Burn with custom mount options, and move root filesystem to `@` subvolume via the `btrfs-config` burn plugin
 * `sdm --burn /dev/sdc --gpt --expand-root /path/to/2023-12-05-raspios-bookworm-arm64.img` &mdash; Burn the IMG to /dev/sdc with a GPT partition table
 
 ## Device names

--- a/Docs/Plugins.md
+++ b/Docs/Plugins.md
@@ -212,6 +212,34 @@ Alternatively, you can use:
 ```
 RasPiOS has a line length limit of 98 for config.txt, and silently ignores characters beyond that length. The bootconfig plugin limits lines to 96 characters.
 
+### btrfs-config
+
+The `btrfs-config` plugin is a `--burn-plugin` to apply btrfs-specific optimizations. It should be used with `--convert-root btrfs`.
+
+The plugin works with both device burns (`--burn`) and file burns (`--burnfile`).
+
+**Note:** You may also want to use `--convert-root-mount-options "compress=zstd"` to save space and IO.
+
+#### Arguments
+
+* **imgtype** &mdash; (Required) The image type being burned
+* **preset** &mdash; Subvolume layout preset. Default: `default`
+
+#### Presets
+
+Currently the only preset is `default`, to:
+
+1. move root filesystem to a new `@` subvolume
+2. set `@` subvolume the default of filesystem (filesystem root can still be mounted with `subvol=/`)
+3. add `rootflags=subvol=@` to cmdline.txt
+3. set mount option `defaults,subvol=@,compress=zstd,noatime,nodiratime` to fstab
+
+Other settings can be defined as new preset. One can also mount again after `sdm --burn` completes and tune as needed.
+
+#### Examples
+
+* `sdm --burn /dev/sdc --convert-root btrfs --expand-root --burn-plugin btrfs-config /path/to/raspios.img` &mdash; Burn to a device with `default` preset
+
 ### btwifiset
 
 btwifiset is a service that enables WiFi SSID and password configuration over Bluetooth using a mobile app. Once the service is running, you can use the `BTBerryWifi` iOS app to connect to the service running on your Pi and configure the WiFi. See https://github.com/nksan/Rpi-SetWiFi-viaBluetooth for details on btwifiset itself.

--- a/plugins/btrfs-config
+++ b/plugins/btrfs-config
@@ -4,7 +4,7 @@
 #
 # The plugin is a burn plugin and must be invoked during a burn operation with --burn-plugin
 #
-# Invoke it on the burn command: --convert-root btrfs --burn-plugin btrfs-config
+# Invoke it on the burn command: --convert-root btrfs --burn-plugin btrfs-config:"preset=default"
 
 function loadparams() {
     source $SDMPT/etc/sdm/sdm-readparams
@@ -19,7 +19,7 @@ phase=$1
 pfx="$(basename $0)"     #For messages
 args="$2"
 loadparams
-vldargs="|burndev|burnfilefile|imgtype|"
+vldargs="|burndev|burnfilefile|imgtype|preset|"
 rqdargs="|imgtype|"
 assetdir="$SDMPT/etc/sdm/assets/$pfx"
 
@@ -35,52 +35,119 @@ function logtobothex() {
     exit 1
 }
 
+function ispdevp() {
+    local dev="$1"
+    [[ "$dev" =~ "mmcblk" ]] || [[ "$dev" =~ "nvme" ]] && return 0 || return 1
+}
+
+function getspname() {
+    local dev="$1" pn="$2"
+    ispdevp $dev && echo "${dev}p${pn}" || echo "${dev}${pn}"
+}
+
+function btrfs_cleanup() {
+    grep -qs "$SDMPT" /proc/mounts && umount -v "$SDMPT"
+    [[ -d "$SDMPT" ]] && rmdir "$SDMPT" 2>/dev/null
+    [[ -n "$loopdev" ]] && losetup -d "$loopdev" 2>/dev/null
+}
+
+function btrfs_exit() {
+    echo "? Plugin $pfx: $1"
+    btrfs_cleanup
+    exit 1
+}
+
 [[ "|0|1|post-install|" =~ "|$phase|" ]] && logtobothex "? Plugin $pfx: This plugin is a burn plugin for use with --burn-plugin rather than --plugin"
 
 if [ "$phase" == "burn-complete" ]
 then
     plugin_getargs $pfx "$args" "$vldargs" "$rqdargs" || exit
     plugin_printkeys
-    echo ""
-    echo ">"
-    echo "> This plugin provides a burn plugin framework but does not yet have a working btrfs configuration"
-    echo "> so is not yet functional"
-    echo ">"
-    echo "> Please feel free to work on it and contribute your updates to the sdm github by opening an issue"
-    echo "> (NOT a pull request, please).
-    echo ">"
-    echo "> Thanks!"
-    echo ""
-    exit 0
 
-    declare -x SDMPT=$(makemtpt)
-    mount -v ${burndev}2 $SDMPT
+    [[ -z "$preset" ]] && preset="default"
 
-    echo "> Create btrfs subvolumes"
-    btrfs subvolume create $SDMPT/@
-    btrfs subvolume create $SDMPT/@home
-    btrfs subvolume create $SDMPT/@var_log
+    case "$preset" in
+        default)
+            #
+            # Subvolume layout: @ (rootfs)
+            #
+            loopdev=""
 
-    echo "> Move system directories into subvolumes"
-    rsync -aHAX $SDMPT/home/ $SDMPT/@home/
-    rm -rf $SDMPT/home
-    rsync -aHAX $SDMPT/var/log/ $SDMPT/@var_log/
-    rm -rf $SDMPT/var/log
+            # Resolve boot and root partition device names
+            if [[ -n "$burndev" ]]
+            then
+                echo "> Plugin $pfx: Configure btrfs subvolumes on device '$burndev'"
+                bootpart=$(getspname $burndev 1)
+                rootpart=$(getspname $burndev 2)
+            else
+                echo "> Plugin $pfx: Configure btrfs subvolumes on IMG '$burnfilefile'"
+                loopdev=$(losetup --show --partscan --find "$burnfilefile") || btrfs_exit "Failed to set up loop device for '$burnfilefile'"
+                [[ -n "$loopdev" ]] || btrfs_exit "Failed to set up loop device for '$burnfilefile'"
+                bootpart="${loopdev}p1"
+                rootpart="${loopdev}p2"
+            fi
 
-    echo "> Update /etc/fstab"
-    root_uuid=$(sudo blkid -s UUID -o value "${burndev}2")
-    boot_uuid=$(sudo blkid -s UUID -o value "${burndev}1")
-    echo "root_uuid:|$root_uuid| boot_uuid:|$boot_uuid|"
-    
-    sed -i '/ \/ /d' $SDMPT/etc/fstab        #Remove rootfs line
-    cat >> $SDMPT/etc/fstab <<EOF
+            # Mount top-level btrfs
+            declare -x SDMPT=$(makemtpt)
+            echo "> Plugin $pfx: Mount btrfs top-level (subvol=/) from $rootpart on $SDMPT"
+            mount -o subvol=/ "$rootpart" "$SDMPT" || btrfs_exit "Failed to mount $rootpart on $SDMPT"
 
-# mount btrfs subvolumes
+            # Create @ subvolume and move all top-level contents into it
+            echo "> Plugin $pfx: Create btrfs subvolume @"
+            btrfs subvolume create "$SDMPT/@" || btrfs_exit "Failed to create subvolume @"
 
-UUID=$root_uuid  /home     btrfs  subvol=@home,compress=zstd,noatime     0  0
-UUID=$root_uuid  /var/log  btrfs  subvol=@var_log,compress=zstd,noatime  0  0
-#UUID=$boot_uuid  /boot     vfat   defaults                               0  2
+            echo "> Plugin $pfx: Move top-level contents into @ subvolume"
+            for item in "$SDMPT"/*
+            do
+                bname=$(basename "$item")
+                [[ "$bname" = '@' ]] && continue
+                mv -v "$item" "$SDMPT/@/" || btrfs_exit "Failed to move '$bname' into @"
+            done
+
+            # Update /etc/fstab
+            echo "> Plugin $pfx: Update /etc/fstab"
+            root_uuid=$(blkid -s UUID -o value "$rootpart")
+            [[ -n "$root_uuid" ]] || btrfs_exit "Failed to get UUID for $rootpart"
+
+            sed -i '/ \/ /d' "$SDMPT/@/etc/fstab"
+            cat >> "$SDMPT/@/etc/fstab" <<EOF
+
+# btrfs subvolume mount
+UUID=$root_uuid  /  btrfs  defaults,subvol=@,compress=zstd,noatime,nodiratime  0  0
 EOF
-    umount -v $SDMPT
+            echo "> Plugin $pfx: fstab updated with UUID=$root_uuid subvol=@ and other options"
+
+            # Set default subvolume to @
+            # Allows booting even if subvol=@ is removed in cmdline.txt and fstab
+            echo "> Plugin $pfx: Set default subvolume to @"
+            btrfs subvolume set-default "$SDMPT/@" \
+                || echo "% Plugin $pfx: Warning: Failed to set default subvolume; cmdline.txt rootflags will be relied upon"
+
+            # Update cmdline.txt
+            umount -v "$SDMPT"
+            echo "> Plugin $pfx: Mount boot partition $bootpart to update cmdline.txt"
+            mount -v "$bootpart" "$SDMPT" || btrfs_exit "Failed to mount boot partition $bootpart"
+
+            if [[ -f "$SDMPT/cmdline.txt" ]]
+            then
+                if ! grep -q "rootflags=subvol=@" "$SDMPT/cmdline.txt"
+                then
+                    echo "> Plugin $pfx: Append rootflags=subvol=@ to cmdline.txt"
+                    sed -i 's/$/ rootflags=subvol=@/' "$SDMPT/cmdline.txt"
+                else
+                    echo "> Plugin $pfx: cmdline.txt already contains rootflags=subvol=@"
+                fi
+            else
+                echo "% Plugin $pfx: Warning: cmdline.txt not found on boot partition"
+            fi
+
+            # Cleanup
+            echo "> Plugin $pfx: Cleanup"
+            btrfs_cleanup
+            echo "> Plugin $pfx: btrfs subvolume configuration complete"
+            ;;
+        *)
+            logtobothex "? Plugin $pfx: Unknown preset '$preset'"
+            ;;
+    esac
 fi
-exit

--- a/plugins/btrfs-config
+++ b/plugins/btrfs-config
@@ -146,6 +146,11 @@ EOF
             btrfs_cleanup
             echo "> Plugin $pfx: btrfs subvolume configuration complete"
             ;;
+        next)
+            # This preset is a placeholder to demonstrate how to add a new preset.
+            # It is not yet implemented.
+            logtobothex "? Plugin $pfx: Preset 'next' is not yet implemented"
+            ;;
         *)
             logtobothex "? Plugin $pfx: Unknown preset '$preset'"
             ;;

--- a/sdm
+++ b/sdm
@@ -287,6 +287,7 @@ csrc=""                     #Source directory for use by Custom Phase script
 cscript=""                  #Custom Phase script
 cvtrootext=""               #With --convert-root set rootfs to this size or increase by this amount (with '+')
 cvtrootfs=""                #--convert-root
+cvtrootmountoptions=""      #--convert-root-mount-options
 datefmt="%Y-%m-%d %H:%M:%S" #Default date format for history log
 ddpid=""                    #Holds pid of dd during IMG Extend
 ddextend=0                  #1=use dd for extend instead of qemu-img
@@ -373,7 +374,7 @@ source $src/sdm-cparse           # Get function defs
 #
 cmdline="$0 $*"
 longopts="help,1piboot:,aptcache:,apt-dist-upgrade,aptmaint:,apt-options:,\
-autologin,b0script:,b1script:,batch,bootscripts,burn:,burnfile:,burn-plugin:,chroot,cscript:,convert-root:,csrc:,\
+autologin,b0script:,b1script:,batch,bootscripts,burn:,burnfile:,burn-plugin:,chroot,cscript:,convert-root:,convert-root-mount-options:,csrc:,\
 customize,datefmt:,ddextend,ddsw:,debug:,directory,domain:,ecolors:,encrypted,explore,expand-at-boot,expand-root,extend,\
 extract-log:,extract-logs:,extract-script:,gpt,groups:,host:,hostname:,info,keyfile:,loadlocal:,logwidth:,\
 mcolors:,mount,no-expand-root,norestart,noreboot,nowait-timesync,nspawnsw:,oklive,os:,plugin-debug,\
@@ -416,6 +417,7 @@ do
 	--burn-plugin) burnplugins=$(appendvalue "$burnplugins" "$2" "~") ; shift 2 ;;
 	--chroot)      fchroot=1     ; shift 1 ;;
 	--convert-root) cvtrootfs="${2,,}" ; shift 2 ;;
+	--convert-root-mount-options) cvtrootmountoptions="$2" ; shift 2 ;;
 	--cscript)     cscript=$2    ; shift 2 ;;
 	--csrc)        csrc=$2       ; shift 2 ;;
 	--customize)   fcustomize=1  ; shift 1 ;;

--- a/sdm-cmdsubs
+++ b/sdm-cmdsubs
@@ -106,7 +106,7 @@ function copybypart() {
     #
     # Copy the partitions one at a time and change rootfs format
     #
-    local srcdev="$1" dstdev="$2" dsttype="${3:-dos}" fstype="${4:-ext4}" fsext="$5"
+    local srcdev="$1" dstdev="$2" dsttype="${3:-dos}" fstype="${4:-ext4}" fsext="$5" mopts="$6"
     local fatnum fatstart fatend fatsize
     local extnum extstart extend extsize extext
     local misc p1 p2 rootfs
@@ -290,7 +290,7 @@ function copybypart() {
 	zfs unmount rpool/ROOT/debian
     fi
 
-    domount $dstdev "Device" $SDMPT $fstype
+    domount $dstdev "Device" $SDMPT $fstype "$mopts"
     write_burnmsg "> Copy bootfs to $dstdev"
     rsync -aH $msdir/ $mddir
     errifrc $? "? Error copying bootfs partition to $dstdev"
@@ -381,7 +381,7 @@ EOF
 	    [ "$hname" == "" ] && vgname="vg1" || vgname=$hname
 	    mapper="/dev/mapper/$vgname-rootfs"
 	    fpartcopy=1
-	    copybypart $dimg $burndev $pt $cvtrootfs $cvtrootext
+	    copybypart $dimg $burndev $pt $cvtrootfs "$cvtrootext" "$cvtrootmountoptions"
 	    fpartcopy=0
 	    docleanup
 	    sync ; sleep 1 ; sync
@@ -389,7 +389,7 @@ EOF
 	partprobe $burndev
 	sync ; sleep 1 ; sync
 	declare -x SDMPT=$(makemtpt)
-	domount "$burndev" "Device" $SDMPT $cvtrootfs
+	domount "$burndev" "Device" $SDMPT $cvtrootfs "$cvtrootmountoptions"
     else
 	#
 	# Burning to a file
@@ -425,7 +425,7 @@ EOF
 	losetup -d $loopdev
 	sync ; sleep 1 ; sync
 	declare -x SDMPT=$(makemtpt)
-	domount "$burnfilefile" "IMG" $SDMPT $cvtrootfs
+	domount "$burnfilefile" "IMG" $SDMPT $cvtrootfs "$cvtrootmountoptions"
 	expandroot=1           # Force Expand Root into the newly written IMG so it will happen when burned to something with sdm
     fi
     #

--- a/sdm-cmdsubs
+++ b/sdm-cmdsubs
@@ -179,6 +179,7 @@ function copybypart() {
 	errifrc $? "? Error creating root partition on $dstdev"
     fi
     partprobe $dstdev
+    sleep 3 # to workaround "No such file or directory" still happens
 
     #declare -x SDMPT=$(makemtpt)
     #declare -x SDMPX=$(makemtptX)

--- a/sdm-cparse
+++ b/sdm-cparse
@@ -1988,9 +1988,10 @@ function domount() {
     # $2: "Directory" "IMG" or "Device"
     # $3: mount point (D:$SDMPT)
     # $4: fstype
+    # $5: mount options (optional, e.g. "compress=zstd,noatime")
     # Tree will be mounted on the mountpoint, which must be set with makemtpt or makemtptX
     #
-    local dmimg=$1 imgtype=$2 mpoint=${3} fstype=$4
+    local dmimg=$1 imgtype=$2 mpoint=${3} fstype=$4 mopts=$5
     local p1="1" p2="2" pinfo csize bootstart bootsize rootstart rootsize mdir sts rootfsd lv=0 kf=""
 
     [ "$mpoint" == "" ] && mpoint=$SDMPT
@@ -2072,7 +2073,7 @@ function domount() {
 	    else
 		if [ "$fstype" != "zfs" ]
 		then
-		    mount -v ${dmimg}${p2} $mpoint
+		    mount -v ${mopts:+-o $mopts} ${dmimg}${p2} $mpoint
 		else
 		    zfs mount rpool/ROOT/debian
 		fi


### PR DESCRIPTION
- Revive the plugin to enable `--burn-plugin btrfs-config` , with a basic configuration
- Add `--convert-root-mount-options` that applies to all `--convert-root fs`. The option is added to enable compression before coping files, but could be used for other purposes too

closes https://github.com/gitbls/sdm/issues/395